### PR TITLE
Use implicit JsonSerializable interface instead of Serializer

### DIFF
--- a/src/Controller/NotificationController.php
+++ b/src/Controller/NotificationController.php
@@ -45,19 +45,16 @@ class NotificationController extends AbstractController
      *     name="notifications_all",
      *     options={"expose"=true}
      * )
-     * @param SerializerInterface $serializer
      * @return JsonResponse
      */
-    public function notifications(SerializerInterface $serializer)
+    public function notifications()
     {
         return new JsonResponse([
-            'notifications' => $serializer->serialize(
+            'notifications' =>
                 $this->notificationRepository->findBy([
                     'seen' => false,
                     'user' => $this->getUser()
                 ]),
-                'json'
-            )
         ]);
     }
 }

--- a/src/Entity/LikeNotification.php
+++ b/src/Entity/LikeNotification.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity(repositoryClass=LikeNotificationRepository::class)
  */
-class LikeNotification extends Notification
+class LikeNotification extends Notification implements \JsonSerializable
 {
     /**
      * @ORM\ManyToOne(targetEntity="App\Entity\Post")
@@ -50,5 +50,13 @@ class LikeNotification extends Notification
     public function setLikedBy($likedBy): void
     {
         $this->likedBy = $likedBy;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'likedBy' => $this->getLikedBy(),
+            'post'    => $this->getPost()
+        ];
     }
 }

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Entity(repositoryClass=PostRepository::class)
  * @ORM\HasLifecycleCallbacks()
  */
-class Post
+class Post implements \JsonSerializable
 {
     /**
      * @ORM\Id()
@@ -132,5 +132,14 @@ class Post
         }
 
         $this->likedBy->add($user);
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'text' => $this->text,
+            'time' => $this->time ? $this->time->format(\DateTime::ISO8601) : null,
+            'user' => $this->getUser()
+        ];
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @UniqueEntity(fields="email", message="This email address is already in use")
  * @UniqueEntity(fields="username", message="This username is already in use")
  */
-class User implements UserInterface, \Serializable
+class User implements UserInterface, \Serializable, \JsonSerializable
 {
     const ROLE_USER = 'ROLE_USER';
     const ROLE_ADMIN = 'ROLE_ADMIN';
@@ -281,5 +281,13 @@ class User implements UserInterface, \Serializable
     public function getPostsLiked(): Collection
     {
         return $this->postsLiked;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'id'       => $this->id,
+            'username' => $this->username,
+        ];
     }
 }


### PR DESCRIPTION
I've used the JsonSerializable interface for serialization. It gets called implicitly on json_encode.

I've also removed the `$serializer->serialize(...)` call, as it returns a string, and the resulting decoded JSON by the client was of the form:
```javascript
{
  notifications: "[{likedBy: {id: 2, username: "rob_smith"},…}]"
}
```

I don't think I have a better suggestion than the current PR. From one point of view, Serializable provides an easy way to dump an object into JSON. However, apart from the circular reference issue, it can also expose the private user information in polling calls (password, emails, etc).

I know response types can be a mess to deal with, I JSON encode hand-rolled array structures in my controllers instead of a uniform interface.

A possible suggestion would be to extend the way JsonSerializable is used, such as the array returned is based on related entities that have been already resolved, and are not proxy getters. Pseudocode as I don't know the types involved directly

```php
public function jsonSerialize()
{
    $result = [];
    if ($this->user instanceof PROXY_TYPE::CLASS) {
        $result['user'] = $this->user;
    }
    return $result;
}
```

That way the query used to fetch results would dictate the serialized response. But I'm just throwing out ideas here, as circular references are still possible if too many relationships are fetched. 